### PR TITLE
Added explicit type conversion in const at()

### DIFF
--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -89,7 +89,7 @@ class Bitfields
     constexpr const UnderlyingType& at() const noexcept
     {
         constexpr auto idx{ find_field_index<FieldId>() };
-        auto& result{ field_values[idx] };
+        auto& result{ (UnderlyingType&) field_values[idx] };
         result &= non_shifted_field_masks[idx];
         return result;
     }


### PR DESCRIPTION
Needed by new version of Visual Studio 2022 compiler