### PR TITLE
Bitfields template class type parameter alias

### DIFF
--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -59,10 +59,12 @@ struct Field
     static inline constexpr auto size{Size};
 };
 
-template<typename UnderlyingType, typename... Fields>
+template<typename UT, typename... Fields>
 class Bitfields
 {
   public:
+    using UnderlyingType = UT;
+
     constexpr Bitfields() = default;
 
     constexpr Bitfields(UnderlyingType preload)


### PR DESCRIPTION
Add a template parameter type alias to the Bitfields template class to facilitate use in scenarios where that UnderlyingType is shared.

For example, if this library is combined with the Embedded Template Library [io_port](https://www.etlcpp.com/io_port.html), it is clearer and more explicit to refer to the type alias of specialized Bitfields types when declaring io_port wrappers.