### PR TITLE
Feature/add clang tidy and format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,26 @@
+# This is the formatting configuration file used by clangd based on styles.
+# You can use any of the possible style values listed below
+
+# For each input file clang-format will try to find the .clang-format file 
+# located in the closest parent directory of the input file.
+
+BasedOnStyle: Google
+
+# Possible values:
+# LLVM      - A style complying with the LLVM coding standards - https://llvm.org/docs/CodingStandards.html
+# Google    - A style complying with Google C++ style guide - https://google.github.io/styleguide/cppguide.html
+# Chromium  - A style complying with Chromium style guide - https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md
+# Mozilla   - A style complying with Mozilla style guide - https://firefox-source-docs.mozilla.org/code-quality/coding-style/coding_style_cpp.html
+# WebKit    - A style complying with WebKit style guide - https://www.webkit.org/code-style-guidelines/
+
+# For more information you can check:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+# Additional Customizations
+# Note that clang-format seems to be sensitive to the spacing and whitespace within configuration files such as this one.
+# Ensure there are no extra spaces prior to root level configuration items, and that level 1 sub-items are indented 4 spaces, etc.
+# Otherwise, the tool appears to revert to some default configuration.
+
+# Allow PC-lint message suppression with single-line comments. The "lint"
+# at the start of the comment must lie immediately adjacent to the "//".
+CommentPragmas: '^lint'

--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ BasedOnStyle: Google
 # Note that clang-format seems to be sensitive to the spacing and whitespace within configuration files such as this one.
 # Ensure there are no extra spaces prior to root level configuration items, and that level 1 sub-items are indented 4 spaces, etc.
 # Otherwise, the tool appears to revert to some default configuration.
+ColumnLimit: 120
 
 # Allow PC-lint message suppression with single-line comments. The "lint"
 # at the start of the comment must lie immediately adjacent to the "//".

--- a/.clang-format
+++ b/.clang-format
@@ -22,6 +22,11 @@ BasedOnStyle: Google
 # Otherwise, the tool appears to revert to some default configuration.
 ColumnLimit: 120
 
+# Prevents clang-format from packing parameters/arguments onto a single line 
+# if they don't fit within the ColumnLimit.
+BinPackParameters: false
+BinPackArguments: false 
+
 # Allow PC-lint message suppression with single-line comments. The "lint"
 # at the start of the comment must lie immediately adjacent to the "//".
 CommentPragmas: '^lint'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,87 @@
+---
+Checks: '-*,bugprone-*,cert-*,clang-*, clang-analyzer-*, cppcoreguidelines-*,google-*,hicpp-*,llvm-else-after-return,llvm-header-guard,llvm-namespace-comment,llvm-prefer-*,llvm-qualified-auto,llvm-twine-local,misc-*,modernize-avoid-*,modernize-concat-nested-namespaces,modernize-deprecated-*,modernize-loop-convert,modernize-make-*,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-replace-*,modernize-return-braced-init-list,modernize-shrink-to-fit,modernize-unary-static-assert,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-emplace,modernize-use-equals-*,modernize-use-nodiscard,modernize-use-noexcept,modernize-use-nullptr,modernize-use-override,modernize-use-transparent-functors,modernize-use-uncaught-exceptions,modernize-use-using,performance-*,readability-*,-google-readability-todo,-modernize-use-nodiscard,-readability-avoid-const-params-in-decls'
+WarningsAsErrors: 'bugprone-,cert-,cppcoreguidelines-*'
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: '.cpm_cache'
+FormatStyle:     none
+CheckOptions:
+  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
+  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
+  hicpp-special-member-functions.AllowSoleDefaultDtor: true
+
+  # See https://github.com/llvm/llvm-project/issues/42391
+  performance-move-const-arg.CheckTriviallyCopyableMove: false
+  hicpp-move-const-arg.CheckTriviallyCopyableMove: false
+  performance-move-const-arg.CheckMoveToConstRef: false
+  hicpp-move-const-arg.CheckMoveToConstRef: false
+
+  # Variables and constants should be camelCase
+  readability-identifier-naming.VariableCase: camelBack
+
+  # Functions should be camelCase
+  readability-identifier-naming.FunctionCase: camelBack
+
+  # Classes, structs, unions, enums, and namespaces should be PascalCase
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.StructCase: CamelCase
+  readability-identifier-naming.UnionCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.NamespaceCase: CamelCase
+
+  # Enumerators should be PascalCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+
+  # Macros should be ALL_CAPS
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+
+  # Global constants should be ALL_CAPS
+  readability-identifier-naming.GlobalConstantCase: UPPER_CASE
+
+  # Non-local constants should be ALL_CAPS
+  readability-identifier-naming.ClassConstantCase: UPPER_CASE
+  readability-identifier-naming.ConstexprVariableCase: UPPER_CASE
+
+  # Interfaces should be prefixed with "I"
+  readability-identifier-naming.AbstractClassPrefix: I
+
+  # Non-public data members should be prefixed with "m_"
+  readability-identifier-naming.PrivateMemberPrefix: m_
+  readability-identifier-naming.ProtectedMemberPrefix: m_
+
+  # Static data members should be prefixed with "s_"
+  readability-identifier-naming.StaticConstantPrefix: s_
+
+  # Typedefs and aliases should be PascalCase
+  readability-identifier-naming.TypedefCase: CamelCase
+  readability-identifier-naming.TypeAliasCase: CamelCase
+
+  # # Add these new options for include-cleaner configuration
+  # misc-include-cleaner.IgnoreHeaders: '.*\.hpp$'
+  # misc-include-cleaner.IgnoreHeadersFromHeaders: true
+
+  # misc-include-cleaner.IgnoreHeaders: '.*/vpu/.*\.hpp$'
+  # misc-include-cleaner.IgnoreHeadersFromHeaders: true
+  # misc-include-cleaner.ParseIncludes: true
+  # misc-include-cleaner.IncludeStyle: 'llvm'
+
+    # Include cleaner configuration that matches your project structure
+  misc-include-cleaner.IgnoreHeaders: '.*'
+  misc-include-cleaner.IgnoreHeadersFromHeaders: true
+  misc-include-cleaner.StrictnessLevel: 'low'
+  misc-include-cleaner.DeduplicateFindings: true
+
+
+  # misc-include-cleaner.IgnoreHeaders: '.*\.hpp$'
+  # misc-include-cleaner.IgnoreHeadersFromHeaders: true
+  # misc-include-cleaner.StrictnessLevel: 'low'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+.vscode/
+.devcontainer/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cinttypes": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "cinttypes": "cpp"
-    }
-}

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -111,7 +111,7 @@ class Bitfields {
   }
 
   static inline constexpr auto to_non_shifted_field_masks() noexcept {
-    std::array<UnderlyingType, NumberOfFields> field_masks = {};
+    std::array<UnderlyingType, NumberOfFields> masks = {};
 
     for (unsigned i{0}; i < NumberOfFields; ++i) {
       auto field_size{static_cast<UnderlyingType>(field_sizes[i])};
@@ -120,10 +120,10 @@ class Bitfields {
       // undefined behavior; see:
       // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
       auto one{static_cast<UnderlyingType>(1)};
-      field_masks[i] = (one << field_size) - 1;
+      masks[i] = static_cast<UnderlyingType>((one << field_size) - 1);
     }
 
-    return field_masks;
+    return masks;
   }
 
   static inline constexpr auto to_shifted_field_masks() noexcept {

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -34,8 +34,7 @@ constexpr T accumulate(InputIt first, InputIt last, T init) {
 }
 
 template <class InputIt, class OutputIt, class UnaryOperation>
-constexpr OutputIt transform(InputIt first1, InputIt last1, OutputIt d_first,
-                             UnaryOperation unary_op) {
+constexpr OutputIt transform(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op) {
   while (first1 != last1) {
     *d_first++ = unary_op(*first1++);
   }
@@ -93,9 +92,7 @@ class Bitfields {
     return result;
   }
 
-  constexpr UnderlyingType serialize() const noexcept {
-    return (extract<Fields::id>() | ... | 0);
-  }
+  constexpr UnderlyingType serialize() const noexcept { return (extract<Fields::id>() | ... | 0); }
 
  private:
   static inline constexpr auto to_field_shifts() noexcept {
@@ -143,8 +140,7 @@ class Bitfields {
 
   template <auto FieldId>
   static inline constexpr auto find_field_index() noexcept {
-    constexpr auto it{
-        detail::find(std::begin(field_ids), std::end(field_ids), FieldId)};
+    constexpr auto it{detail::find(std::begin(field_ids), std::end(field_ids), FieldId)};
     static_assert(it != std::end(field_ids), "Field ID not found");
     return static_cast<unsigned>(std::distance(std::begin(field_ids), it));
   }
@@ -161,28 +157,23 @@ class Bitfields {
   }
 
   static inline constexpr unsigned calculate_occupied_bit_size() {
-    return detail::accumulate(std::begin(field_sizes), std::end(field_sizes),
-                              0u);
+    return detail::accumulate(std::begin(field_sizes), std::end(field_sizes), 0u);
   }
 
   static inline constexpr unsigned NumberOfFields{sizeof...(Fields)};
   static inline constexpr unsigned UnderlyingTypeSize{sizeof(UnderlyingType)};
-  static inline constexpr unsigned UnderlyingTypeBitSize{UnderlyingTypeSize *
-                                                         CHAR_BIT};
+  static inline constexpr unsigned UnderlyingTypeBitSize{UnderlyingTypeSize * CHAR_BIT};
 
   static inline constexpr std::array field_ids{Fields::id...};
   static inline constexpr std::array field_sizes{Fields::size...};
   static inline constexpr auto field_shifts{to_field_shifts()};
-  static inline constexpr auto non_shifted_field_masks{
-      to_non_shifted_field_masks()};
+  static inline constexpr auto non_shifted_field_masks{to_non_shifted_field_masks()};
   static inline constexpr auto field_masks{to_shifted_field_masks()};
 
-  static_assert(std::is_integral<UnderlyingType>::value,
-                "UnderlyingType must be an integral type");
+  static_assert(std::is_integral<UnderlyingType>::value, "UnderlyingType must be an integral type");
   static_assert(!has_duplicates(), "Field IDs must not duplicate");
-  static_assert(
-      calculate_occupied_bit_size() == UnderlyingTypeBitSize,
-      "Accumulated bit size is not equal to underlying type's bit size");
+  static_assert(calculate_occupied_bit_size() == UnderlyingTypeBitSize,
+                "Accumulated bit size is not equal to underlying type's bit size");
 
   std::array<UnderlyingType, NumberOfFields> field_values = {};
 };

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -61,7 +61,7 @@ class Bitfields {
       auto mask{field_masks[i]};
       auto masked_value{mask & preload};
       auto shift{field_shifts[i]};
-      field_values[i] = masked_value >> shift;
+      field_values[i] = static_cast<UnderlyingType>(masked_value >> shift);
     }
   }
 

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -132,7 +132,7 @@ class Bitfields {
     for (unsigned i{0}; i < NumberOfFields; ++i) {
       auto mask{non_shifted_field_masks[i]};
       auto shift{field_shifts[i]};
-      masks[i] = mask << shift;
+      masks[i] = static_cast<UnderlyingType>(mask << shift);
     }
 
     return masks;

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -12,200 +12,181 @@
 #include <iterator>
 #include <type_traits>
 
-namespace jungles
-{
+namespace jungles {
 
-namespace detail
-{
-template<class InputIt, class T>
-constexpr InputIt find(InputIt first, InputIt last, const T& value)
-{
-    for (; first != last; ++first)
-    {
-        if (*first == value)
-        {
-            return first;
-        }
+namespace detail {
+template <class InputIt, class T>
+constexpr InputIt find(InputIt first, InputIt last, const T& value) {
+  for (; first != last; ++first) {
+    if (*first == value) {
+      return first;
     }
-    return last;
+  }
+  return last;
 }
 
-template<class InputIt, class T>
-constexpr T accumulate(InputIt first, InputIt last, T init)
-{
-    for (; first != last; ++first)
-    {
-        init = std::move(init) + *first;
-    }
-    return init;
+template <class InputIt, class T>
+constexpr T accumulate(InputIt first, InputIt last, T init) {
+  for (; first != last; ++first) {
+    init = std::move(init) + *first;
+  }
+  return init;
 }
 
-template<class InputIt, class OutputIt, class UnaryOperation>
-constexpr OutputIt transform(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op)
-{
-    while (first1 != last1)
-    {
-        *d_first++ = unary_op(*first1++);
-    }
-    return d_first;
+template <class InputIt, class OutputIt, class UnaryOperation>
+constexpr OutputIt transform(InputIt first1, InputIt last1, OutputIt d_first,
+                             UnaryOperation unary_op) {
+  while (first1 != last1) {
+    *d_first++ = unary_op(*first1++);
+  }
+  return d_first;
 }
 
-} // namespace detail
+}  // namespace detail
 
-template<auto Id, unsigned Size>
-struct Field
-{
-    static inline constexpr auto id{Id};
-    static inline constexpr auto size{Size};
+template <auto Id, unsigned Size>
+struct Field {
+  static inline constexpr auto id{Id};
+  static inline constexpr auto size{Size};
 };
 
-template<typename UT, typename... Fields>
-class Bitfields
-{
-  public:
-    using UnderlyingType = UT;
+template <typename UT, typename... Fields>
+class Bitfields {
+ public:
+  using UnderlyingType = UT;
 
-    constexpr Bitfields() = default;
+  constexpr Bitfields() = default;
 
-    constexpr Bitfields(UnderlyingType preload)
-    {
-        for (unsigned i{0}; i < NumberOfFields; ++i)
-        {
-            auto mask{field_masks[i]};
-            auto masked_value{mask & preload};
-            auto shift{field_shifts[i]};
-            field_values[i] = static_cast<UnderlyingType>(masked_value >> shift);
-        }
+  constexpr Bitfields(UnderlyingType preload) {
+    for (unsigned i{0}; i < NumberOfFields; ++i) {
+      auto mask{field_masks[i]};
+      auto masked_value{mask & preload};
+      auto shift{field_shifts[i]};
+      field_values[i] = masked_value >> shift;
+    }
+  }
+
+  template <auto FieldId>
+  constexpr UnderlyingType& at() noexcept {
+    constexpr auto idx{find_field_index<FieldId>()};
+    UnderlyingType& result{field_values[idx]};
+    result &= non_shifted_field_masks[idx];
+    return result;
+  }
+
+  //! const Bitfields do not need overflow to be checked, because it's
+  //! impossible to overflow with construction only.
+  template <auto FieldId>
+  constexpr const UnderlyingType& at() const noexcept {
+    constexpr auto idx{find_field_index<FieldId>()};
+    const UnderlyingType& result{field_values[idx]};
+    return result;
+  }
+
+  template <auto FieldId>
+  constexpr UnderlyingType extract() const noexcept {
+    constexpr auto idx{find_field_index<FieldId>()};
+    constexpr auto shift{field_shifts[idx]};
+    constexpr auto mask{non_shifted_field_masks[idx]};
+    auto v{field_values[idx] & mask};
+    auto result{static_cast<UnderlyingType>(v << shift)};
+    return result;
+  }
+
+  constexpr UnderlyingType serialize() const noexcept {
+    return (extract<Fields::id>() | ... | 0);
+  }
+
+ private:
+  static inline constexpr auto to_field_shifts() noexcept {
+    std::array<unsigned, NumberOfFields> shifts = {};
+
+    auto shifts_it{std::rbegin(shifts)};
+    auto sizes_it{std::rbegin(field_sizes)};
+
+    unsigned accumulated_field_size{0};
+    while (shifts_it != std::rend(shifts)) {
+      *shifts_it++ = accumulated_field_size;
+      accumulated_field_size += *sizes_it++;
     }
 
-    template<auto FieldId>
-    constexpr UnderlyingType& at() noexcept
-    {
-        constexpr auto idx{find_field_index<FieldId>()};
-        UnderlyingType& result{field_values[idx]};
-        result &= non_shifted_field_masks[idx];
-        return result;
+    return shifts;
+  }
+
+  static inline constexpr auto to_non_shifted_field_masks() noexcept {
+    std::array<UnderlyingType, NumberOfFields> field_masks = {};
+
+    for (unsigned i{0}; i < NumberOfFields; ++i) {
+      auto field_size{static_cast<UnderlyingType>(field_sizes[i])};
+      // Funny! This is needed, because if we write: (1 << field_size) compiler
+      // will use type 'int' for one, and shifting (int << uint64_t) is
+      // undefined behavior; see:
+      // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
+      auto one{static_cast<UnderlyingType>(1)};
+      field_masks[i] = (one << field_size) - 1;
     }
 
-    //! const Bitfields do not need overflow to be checked, because it's impossible to overflow with construction only.
-    template<auto FieldId>
-    constexpr const UnderlyingType& at() const noexcept
-    {
-        constexpr auto idx{find_field_index<FieldId>()};
-        const UnderlyingType& result{field_values[idx]};
-        return result;
+    return field_masks;
+  }
+
+  static inline constexpr auto to_shifted_field_masks() noexcept {
+    std::array<UnderlyingType, NumberOfFields> masks = {};
+
+    for (unsigned i{0}; i < NumberOfFields; ++i) {
+      auto mask{non_shifted_field_masks[i]};
+      auto shift{field_shifts[i]};
+      masks[i] = mask << shift;
     }
 
-    template<auto FieldId>
-    constexpr UnderlyingType extract() const noexcept
-    {
-        constexpr auto idx{find_field_index<FieldId>()};
-        constexpr auto shift{field_shifts[idx]};
-        constexpr auto mask{non_shifted_field_masks[idx]};
-        auto v{field_values[idx] & mask};
-        auto result{static_cast<UnderlyingType>(v << shift)};
-        return result;
+    return masks;
+  }
+
+  template <auto FieldId>
+  static inline constexpr auto find_field_index() noexcept {
+    constexpr auto it{
+        detail::find(std::begin(field_ids), std::end(field_ids), FieldId)};
+    static_assert(it != std::end(field_ids), "Field ID not found");
+    return static_cast<unsigned>(std::distance(std::begin(field_ids), it));
+  }
+
+  static inline constexpr bool has_duplicates() {
+    auto beg{std::begin(field_ids)}, end{std::end(field_ids)};
+
+    for (auto it{beg}; it != end; ++it) {
+      auto match_it{detail::find(std::next(it), end, *it)};
+      if (match_it != end) return true;
     }
 
-    constexpr UnderlyingType serialize() const noexcept
-    {
-        return (extract<Fields::id>() | ... | 0);
-    }
+    return false;
+  }
 
-  private:
-    static inline constexpr auto to_field_shifts() noexcept
-    {
-        std::array<unsigned, NumberOfFields> shifts = {};
+  static inline constexpr unsigned calculate_occupied_bit_size() {
+    return detail::accumulate(std::begin(field_sizes), std::end(field_sizes),
+                              0u);
+  }
 
-        auto shifts_it{std::rbegin(shifts)};
-        auto sizes_it{std::rbegin(field_sizes)};
+  static inline constexpr unsigned NumberOfFields{sizeof...(Fields)};
+  static inline constexpr unsigned UnderlyingTypeSize{sizeof(UnderlyingType)};
+  static inline constexpr unsigned UnderlyingTypeBitSize{UnderlyingTypeSize *
+                                                         CHAR_BIT};
 
-        unsigned accumulated_field_size{0};
-        while (shifts_it != std::rend(shifts))
-        {
-            *shifts_it++ = accumulated_field_size;
-            accumulated_field_size += *sizes_it++;
-        }
+  static inline constexpr std::array field_ids{Fields::id...};
+  static inline constexpr std::array field_sizes{Fields::size...};
+  static inline constexpr auto field_shifts{to_field_shifts()};
+  static inline constexpr auto non_shifted_field_masks{
+      to_non_shifted_field_masks()};
+  static inline constexpr auto field_masks{to_shifted_field_masks()};
 
-        return shifts;
-    }
+  static_assert(std::is_integral<UnderlyingType>::value,
+                "UnderlyingType must be an integral type");
+  static_assert(!has_duplicates(), "Field IDs must not duplicate");
+  static_assert(
+      calculate_occupied_bit_size() == UnderlyingTypeBitSize,
+      "Accumulated bit size is not equal to underlying type's bit size");
 
-    static inline constexpr auto to_non_shifted_field_masks() noexcept
-    {
-        std::array<UnderlyingType, NumberOfFields> masks = {};
-
-        for (unsigned i{0}; i < NumberOfFields; ++i)
-        {
-            auto field_size{static_cast<UnderlyingType>(field_sizes[i])};
-            // Funny! This is needed, because if we write: (1 << field_size) compiler will use type 'int' for one,
-            // and shifting (int << uint64_t) is undefined behavior; see:
-            // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
-            auto one{static_cast<UnderlyingType>(1)};
-            masks[i] = static_cast<UnderlyingType>((one << field_size) - 1);
-        }
-
-        return masks;
-    }
-
-    static inline constexpr auto to_shifted_field_masks() noexcept
-    {
-        std::array<UnderlyingType, NumberOfFields> masks = {};
-
-        for (unsigned i{0}; i < NumberOfFields; ++i)
-        {
-            auto mask{non_shifted_field_masks[i]};
-            auto shift{field_shifts[i]};
-            masks[i] = static_cast<UnderlyingType>(mask << shift);
-        }
-
-        return masks;
-    }
-
-    template<auto FieldId>
-    static inline constexpr auto find_field_index() noexcept
-    {
-        constexpr auto it{detail::find(std::begin(field_ids), std::end(field_ids), FieldId)};
-        static_assert(it != std::end(field_ids), "Field ID not found");
-        return static_cast<unsigned>(std::distance(std::begin(field_ids), it));
-    }
-
-    static inline constexpr bool has_duplicates()
-    {
-        auto beg{std::begin(field_ids)}, end{std::end(field_ids)};
-
-        for (auto it{beg}; it != end; ++it)
-        {
-            auto match_it{detail::find(std::next(it), end, *it)};
-            if (match_it != end)
-                return true;
-        }
-
-        return false;
-    }
-
-    static inline constexpr unsigned calculate_occupied_bit_size()
-    {
-        return detail::accumulate(std::begin(field_sizes), std::end(field_sizes), 0u);
-    }
-
-    static inline constexpr unsigned NumberOfFields{sizeof...(Fields)};
-    static inline constexpr unsigned UnderlyingTypeSize{sizeof(UnderlyingType)};
-    static inline constexpr unsigned UnderlyingTypeBitSize{UnderlyingTypeSize * CHAR_BIT};
-
-    static inline constexpr std::array field_ids{Fields::id...};
-    static inline constexpr std::array field_sizes{Fields::size...};
-    static inline constexpr auto field_shifts{to_field_shifts()};
-    static inline constexpr auto non_shifted_field_masks{to_non_shifted_field_masks()};
-    static inline constexpr auto field_masks{to_shifted_field_masks()};
-
-    static_assert(std::is_integral<UnderlyingType>::value, "UnderlyingType must be an integral type");
-    static_assert(!has_duplicates(), "Field IDs must not duplicate");
-    static_assert(calculate_occupied_bit_size() == UnderlyingTypeBitSize,
-                  "Accumulated bit size is not equal to underlying type's bit size");
-
-    std::array<UnderlyingType, NumberOfFields> field_values = {};
+  std::array<UnderlyingType, NumberOfFields> field_values = {};
 };
 
-} // namespace jungles
+}  // namespace jungles
 
 #endif /* BITFIELDS_HPP */

--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -73,8 +73,7 @@ class Bitfields {
     return result;
   }
 
-  //! const Bitfields do not need overflow to be checked, because it's
-  //! impossible to overflow with construction only.
+  // const Bitfields do not need overflow to be checked, because it's impossible to overflow with construction only.
   template <auto FieldId>
   constexpr const UnderlyingType& at() const noexcept {
     constexpr auto idx{find_field_index<FieldId>()};
@@ -115,10 +114,9 @@ class Bitfields {
 
     for (unsigned i{0}; i < NumberOfFields; ++i) {
       auto field_size{static_cast<UnderlyingType>(field_sizes[i])};
-      // Funny! This is needed, because if we write: (1 << field_size) compiler
-      // will use type 'int' for one, and shifting (int << uint64_t) is
-      // undefined behavior; see:
-      // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
+      // Funny! This is needed, because if we write: (1 << field_size) compilerwill use type 'int' for one, and shifting
+      // (int << uint64_t) is undefined behavior;
+      // see:https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
       auto one{static_cast<UnderlyingType>(1)};
       masks[i] = static_cast<UnderlyingType>((one << field_size) - 1);
     }

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -6,15 +6,6 @@
 #ifndef HELPERS_HPP
 #define HELPERS_HPP
 
-enum class Reg {
-  field1,
-  field2,
-  field3,
-  field4,
-  field5,
-  field6,
-  field7,
-  field8
-};
+enum class Reg { field1, field2, field3, field4, field5, field6, field7, field8 };
 
 #endif /* HELPERS_HPP */

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -6,16 +6,15 @@
 #ifndef HELPERS_HPP
 #define HELPERS_HPP
 
-enum class Reg
-{
-    field1,
-    field2,
-    field3,
-    field4,
-    field5,
-    field6,
-    field7,
-    field8
+enum class Reg {
+  field1,
+  field2,
+  field3,
+  field4,
+  field5,
+  field6,
+  field7,
+  field8
 };
 
 #endif /* HELPERS_HPP */

--- a/tests/test_const.cpp
+++ b/tests/test_const.cpp
@@ -10,8 +10,7 @@
 
 using namespace jungles;
 
-using Bf = Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>,
-                     Field<Reg::field3, 6>>;
+using Bf = Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>, Field<Reg::field3, 6>>;
 
 TEST_CASE("Const bitfields", "[const]") {
   SECTION("Reading bitfields") {

--- a/tests/test_const.cpp
+++ b/tests/test_const.cpp
@@ -5,58 +5,51 @@
  */
 #include <catch2/catch_test_macros.hpp>
 
-#include "jungles/bitfields.hpp"
-
 #include "helpers.hpp"
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-using Bf = Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>, Field<Reg::field3, 6>>;
+using Bf = Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>,
+                     Field<Reg::field3, 6>>;
 
-TEST_CASE("Const bitfields", "[const]")
-{
-    SECTION("Reading bitfields")
+TEST_CASE("Const bitfields", "[const]") {
+  SECTION("Reading bitfields") {
+    const Bf bf{0b1001101001101010};
+    REQUIRE(bf.at<Reg::field1>() == 0b10);
+    REQUIRE(bf.at<Reg::field2>() == 0b01101001);
+    REQUIRE(bf.at<Reg::field3>() == 0b101010);
+  }
+
+  SECTION("Extracting fields") {
+    const Bf bf{0b0110010110010101};
+    REQUIRE(bf.extract<Reg::field1>() == 0b0100000000000000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b0010010110000000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b0000000000010101);
+  }
+
+  SECTION("Serializing bitfields") {
     {
-        const Bf bf{0b1001101001101010};
-        REQUIRE(bf.at<Reg::field1>() == 0b10);
-        REQUIRE(bf.at<Reg::field2>() == 0b01101001);
-        REQUIRE(bf.at<Reg::field3>() == 0b101010);
+      const Bf bf{0b1001101001101010};
+      REQUIRE(bf.serialize() == 0b1001101001101010);
+    }
+    {
+      const Bf bf{0b0110010110010101};
+      REQUIRE(bf.serialize() == 0b0110010110010101);
+    }
+  }
+
+  SECTION("Referencing bitfields") {
+    SECTION("Referencing a const bitfield") {
+      const Bf bf{0b1001101001101010};
+      const auto& f2{bf.at<Reg::field2>()};
+      REQUIRE(f2 == 0b01101001);
     }
 
-    SECTION("Extracting fields")
-    {
-        const Bf bf{0b0110010110010101};
-        REQUIRE(bf.extract<Reg::field1>() == 0b0100000000000000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b0010010110000000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b0000000000010101);
+    SECTION("Const-reference to a field") {
+      Bf bf{0b1001101001101010};
+      const auto& f2{bf.at<Reg::field2>()};
+      REQUIRE(f2 == 0b01101001);
     }
-
-    SECTION("Serializing bitfields")
-    {
-        {
-            const Bf bf{0b1001101001101010};
-            REQUIRE(bf.serialize() == 0b1001101001101010);
-        }
-        {
-            const Bf bf{0b0110010110010101};
-            REQUIRE(bf.serialize() == 0b0110010110010101);
-        }
-    }
-
-    SECTION("Referencing bitfields")
-    {
-        SECTION("Referencing a const bitfield")
-        {
-            const Bf bf{0b1001101001101010};
-            const auto& f2{bf.at<Reg::field2>()};
-            REQUIRE(f2 == 0b01101001);
-        }
-
-        SECTION("Const-reference to a field")
-        {
-            Bf bf{0b1001101001101010};
-            const auto& f2{bf.at<Reg::field2>()};
-            REQUIRE(f2 == 0b01101001);
-        }
-    }
+  }
 }

--- a/tests/test_deserializing.cpp
+++ b/tests/test_deserializing.cpp
@@ -6,59 +6,54 @@
 #include <catch2/catch_test_macros.hpp>
 #include <limits>
 
-#include "jungles/bitfields.hpp"
-
 #include "helpers.hpp"
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-TEST_CASE("Fields are deserialized/loaded", "[desieralization]")
-{
-    SECTION("Zero-initialized by default")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
-        REQUIRE(bf.serialize() == 0);
-    }
+TEST_CASE("Fields are deserialized/loaded", "[desieralization]") {
+  SECTION("Zero-initialized by default") {
+    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
+              Field<Reg::field3, 14>>
+        bf;
+    REQUIRE(bf.serialize() == 0);
+  }
 
-    SECTION("1-bit size bitfields are loaded")
-    {
-        using OneBitSizedBitfieldsRegister = Bitfields<uint8_t,
-                                                       Field<Reg::field1, 1>,
-                                                       Field<Reg::field2, 1>,
-                                                       Field<Reg::field3, 1>,
-                                                       Field<Reg::field4, 1>,
-                                                       Field<Reg::field5, 1>,
-                                                       Field<Reg::field6, 1>,
-                                                       Field<Reg::field7, 1>,
-                                                       Field<Reg::field8, 1>>;
+  SECTION("1-bit size bitfields are loaded") {
+    using OneBitSizedBitfieldsRegister =
+        Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
+                  Field<Reg::field3, 1>, Field<Reg::field4, 1>,
+                  Field<Reg::field5, 1>, Field<Reg::field6, 1>,
+                  Field<Reg::field7, 1>, Field<Reg::field8, 1>>;
 
-        OneBitSizedBitfieldsRegister reg{0b00110101};
+    OneBitSizedBitfieldsRegister reg{0b00110101};
 
-        REQUIRE(reg.at<Reg::field1>() == 0);
-        REQUIRE(reg.at<Reg::field2>() == 0);
-        REQUIRE(reg.at<Reg::field3>() == 1);
-        REQUIRE(reg.at<Reg::field4>() == 1);
-        REQUIRE(reg.at<Reg::field5>() == 0);
-        REQUIRE(reg.at<Reg::field6>() == 1);
-        REQUIRE(reg.at<Reg::field7>() == 0);
-        REQUIRE(reg.at<Reg::field8>() == 1);
-    }
+    REQUIRE(reg.at<Reg::field1>() == 0);
+    REQUIRE(reg.at<Reg::field2>() == 0);
+    REQUIRE(reg.at<Reg::field3>() == 1);
+    REQUIRE(reg.at<Reg::field4>() == 1);
+    REQUIRE(reg.at<Reg::field5>() == 0);
+    REQUIRE(reg.at<Reg::field6>() == 1);
+    REQUIRE(reg.at<Reg::field7>() == 0);
+    REQUIRE(reg.at<Reg::field8>() == 1);
+  }
 
-    SECTION("Three bitfields with straddling")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 5>, Field<Reg::field2, 7>, Field<Reg::field3, 4>> bf{0b0010011000110110};
-        REQUIRE(bf.at<Reg::field1>() == 0b00100);
-        REQUIRE(bf.at<Reg::field2>() == 0b1100011);
-        REQUIRE(bf.at<Reg::field3>() == 0b0110);
-    }
+  SECTION("Three bitfields with straddling") {
+    Bitfields<uint16_t, Field<Reg::field1, 5>, Field<Reg::field2, 7>,
+              Field<Reg::field3, 4>>
+        bf{0b0010011000110110};
+    REQUIRE(bf.at<Reg::field1>() == 0b00100);
+    REQUIRE(bf.at<Reg::field2>() == 0b1100011);
+    REQUIRE(bf.at<Reg::field3>() == 0b0110);
+  }
 
-    SECTION("Getting mask")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 5>, Field<Reg::field3, 4>> bf{
-            std::numeric_limits<uint16_t>::max()};
+  SECTION("Getting mask") {
+    Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 5>,
+              Field<Reg::field3, 4>>
+        bf{std::numeric_limits<uint16_t>::max()};
 
-        REQUIRE(bf.extract<Reg::field1>() == 0b1111111000000000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b0000000111110000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b0000000000001111);
-    }
+    REQUIRE(bf.extract<Reg::field1>() == 0b1111111000000000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b0000000111110000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b0000000000001111);
+  }
 }

--- a/tests/test_deserializing.cpp
+++ b/tests/test_deserializing.cpp
@@ -13,18 +13,14 @@ using namespace jungles;
 
 TEST_CASE("Fields are deserialized/loaded", "[desieralization]") {
   SECTION("Zero-initialized by default") {
-    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
-              Field<Reg::field3, 14>>
-        bf;
+    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
     REQUIRE(bf.serialize() == 0);
   }
 
   SECTION("1-bit size bitfields are loaded") {
     using OneBitSizedBitfieldsRegister =
-        Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
-                  Field<Reg::field3, 1>, Field<Reg::field4, 1>,
-                  Field<Reg::field5, 1>, Field<Reg::field6, 1>,
-                  Field<Reg::field7, 1>, Field<Reg::field8, 1>>;
+        Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 1>, Field<Reg::field4, 1>,
+                  Field<Reg::field5, 1>, Field<Reg::field6, 1>, Field<Reg::field7, 1>, Field<Reg::field8, 1>>;
 
     OneBitSizedBitfieldsRegister reg{0b00110101};
 
@@ -39,18 +35,15 @@ TEST_CASE("Fields are deserialized/loaded", "[desieralization]") {
   }
 
   SECTION("Three bitfields with straddling") {
-    Bitfields<uint16_t, Field<Reg::field1, 5>, Field<Reg::field2, 7>,
-              Field<Reg::field3, 4>>
-        bf{0b0010011000110110};
+    Bitfields<uint16_t, Field<Reg::field1, 5>, Field<Reg::field2, 7>, Field<Reg::field3, 4>> bf{0b0010011000110110};
     REQUIRE(bf.at<Reg::field1>() == 0b00100);
     REQUIRE(bf.at<Reg::field2>() == 0b1100011);
     REQUIRE(bf.at<Reg::field3>() == 0b0110);
   }
 
   SECTION("Getting mask") {
-    Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 5>,
-              Field<Reg::field3, 4>>
-        bf{std::numeric_limits<uint16_t>::max()};
+    Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 5>, Field<Reg::field3, 4>> bf{
+        std::numeric_limits<uint16_t>::max()};
 
     REQUIRE(bf.extract<Reg::field1>() == 0b1111111000000000);
     REQUIRE(bf.extract<Reg::field2>() == 0b0000000111110000);

--- a/tests/test_deserializing.cpp
+++ b/tests/test_deserializing.cpp
@@ -18,9 +18,15 @@ TEST_CASE("Fields are deserialized/loaded", "[desieralization]") {
   }
 
   SECTION("1-bit size bitfields are loaded") {
-    using OneBitSizedBitfieldsRegister =
-        Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 1>, Field<Reg::field4, 1>,
-                  Field<Reg::field5, 1>, Field<Reg::field6, 1>, Field<Reg::field7, 1>, Field<Reg::field8, 1>>;
+    using OneBitSizedBitfieldsRegister = Bitfields<uint8_t,
+                                                   Field<Reg::field1, 1>,
+                                                   Field<Reg::field2, 1>,
+                                                   Field<Reg::field3, 1>,
+                                                   Field<Reg::field4, 1>,
+                                                   Field<Reg::field5, 1>,
+                                                   Field<Reg::field6, 1>,
+                                                   Field<Reg::field7, 1>,
+                                                   Field<Reg::field8, 1>>;
 
     OneBitSizedBitfieldsRegister reg{0b00110101};
 

--- a/tests/test_extracting.cpp
+++ b/tests/test_extracting.cpp
@@ -12,9 +12,7 @@ using namespace jungles;
 
 TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
   SECTION("For three fields, almost evenly aligned") {
-    Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>,
-              Field<Reg::field3, 3>>
-        bf;
+    Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>, Field<Reg::field3, 3>> bf;
 
     bf.at<Reg::field1>() = 0b101;
     bf.at<Reg::field2>() = 0b11;
@@ -26,9 +24,7 @@ TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
   }
 
   SECTION("For four fields, with various sizes") {
-    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 4>,
-              Field<Reg::field3, 1>, Field<Reg::field4, 2>>
-        bf;
+    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 4>, Field<Reg::field3, 1>, Field<Reg::field4, 2>> bf;
 
     bf.at<Reg::field1>() = 0b1;
     bf.at<Reg::field2>() = 0b0101;
@@ -42,10 +38,8 @@ TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
   }
 
   SECTION("For each field having size one") {
-    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
-              Field<Reg::field3, 1>, Field<Reg::field4, 1>,
-              Field<Reg::field5, 1>, Field<Reg::field6, 1>,
-              Field<Reg::field7, 1>, Field<Reg::field8, 1>>
+    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 1>, Field<Reg::field4, 1>,
+              Field<Reg::field5, 1>, Field<Reg::field6, 1>, Field<Reg::field7, 1>, Field<Reg::field8, 1>>
         bf;
 
     bf.at<Reg::field1>() = 0b1;
@@ -76,9 +70,7 @@ TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
 
 TEST_CASE("Extracts bitfields on 4-byte long bitfield", "[extract]") {
   SECTION("For three fields, evenly aligned") {
-    Bitfields<uint32_t, Field<Reg::field1, 11>, Field<Reg::field2, 11>,
-              Field<Reg::field3, 10>>
-        bf;
+    Bitfields<uint32_t, Field<Reg::field1, 11>, Field<Reg::field2, 11>, Field<Reg::field3, 10>> bf;
 
     bf.at<Reg::field1>() = 0b10101010101;
     bf.at<Reg::field2>() = 0b01101101100;
@@ -90,9 +82,7 @@ TEST_CASE("Extracts bitfields on 4-byte long bitfield", "[extract]") {
   }
 
   SECTION("For a two bit bitfield lying across two bytes") {
-    Bitfields<uint32_t, Field<Reg::field1, 15>, Field<Reg::field2, 2>,
-              Field<Reg::field3, 15>>
-        bf;
+    Bitfields<uint32_t, Field<Reg::field1, 15>, Field<Reg::field2, 2>, Field<Reg::field3, 15>> bf;
     bf.at<Reg::field1>() = 0b000001111100000;
     bf.at<Reg::field2>() = 0b11;
     bf.at<Reg::field3>() = 0b000001111100000;

--- a/tests/test_extracting.cpp
+++ b/tests/test_extracting.cpp
@@ -5,106 +5,98 @@
  */
 #include <catch2/catch_test_macros.hpp>
 
-#include "jungles/bitfields.hpp"
-
 #include "helpers.hpp"
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]")
-{
-    SECTION("For three fields, almost evenly aligned")
-    {
-        Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>, Field<Reg::field3, 3>> bf;
+TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
+  SECTION("For three fields, almost evenly aligned") {
+    Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>,
+              Field<Reg::field3, 3>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b101;
-        bf.at<Reg::field2>() = 0b11;
-        bf.at<Reg::field3>() = 0b010;
+    bf.at<Reg::field1>() = 0b101;
+    bf.at<Reg::field2>() = 0b11;
+    bf.at<Reg::field3>() = 0b010;
 
-        REQUIRE(bf.extract<Reg::field1>() == 0b10100000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b00011000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b00000010);
-    }
+    REQUIRE(bf.extract<Reg::field1>() == 0b10100000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b00011000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b00000010);
+  }
 
-    SECTION("For four fields, with various sizes")
-    {
-        Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 4>, Field<Reg::field3, 1>, Field<Reg::field4, 2>>
-            bf;
+  SECTION("For four fields, with various sizes") {
+    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 4>,
+              Field<Reg::field3, 1>, Field<Reg::field4, 2>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b1;
-        bf.at<Reg::field2>() = 0b0101;
-        bf.at<Reg::field3>() = 0b0;
-        bf.at<Reg::field4>() = 0b11;
+    bf.at<Reg::field1>() = 0b1;
+    bf.at<Reg::field2>() = 0b0101;
+    bf.at<Reg::field3>() = 0b0;
+    bf.at<Reg::field4>() = 0b11;
 
-        REQUIRE(bf.extract<Reg::field1>() == 0b10000000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b00101000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b00000000);
-        REQUIRE(bf.extract<Reg::field4>() == 0b00000011);
-    }
+    REQUIRE(bf.extract<Reg::field1>() == 0b10000000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b00101000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b00000000);
+    REQUIRE(bf.extract<Reg::field4>() == 0b00000011);
+  }
 
-    SECTION("For each field having size one")
-    {
-        Bitfields<uint8_t,
-                  Field<Reg::field1, 1>,
-                  Field<Reg::field2, 1>,
-                  Field<Reg::field3, 1>,
-                  Field<Reg::field4, 1>,
-                  Field<Reg::field5, 1>,
-                  Field<Reg::field6, 1>,
-                  Field<Reg::field7, 1>,
-                  Field<Reg::field8, 1>>
-            bf;
+  SECTION("For each field having size one") {
+    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
+              Field<Reg::field3, 1>, Field<Reg::field4, 1>,
+              Field<Reg::field5, 1>, Field<Reg::field6, 1>,
+              Field<Reg::field7, 1>, Field<Reg::field8, 1>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b1;
-        bf.at<Reg::field2>() = 0b0;
-        bf.at<Reg::field3>() = 0b0;
-        bf.at<Reg::field4>() = 0b1;
-        bf.at<Reg::field5>() = 0b0;
-        bf.at<Reg::field6>() = 0b1;
-        bf.at<Reg::field7>() = 0b1;
-        bf.at<Reg::field8>() = 0b0;
+    bf.at<Reg::field1>() = 0b1;
+    bf.at<Reg::field2>() = 0b0;
+    bf.at<Reg::field3>() = 0b0;
+    bf.at<Reg::field4>() = 0b1;
+    bf.at<Reg::field5>() = 0b0;
+    bf.at<Reg::field6>() = 0b1;
+    bf.at<Reg::field7>() = 0b1;
+    bf.at<Reg::field8>() = 0b0;
 
-        REQUIRE(bf.extract<Reg::field1>() == 0b10000000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b00000000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b00000000);
-        REQUIRE(bf.extract<Reg::field4>() == 0b00010000);
-        REQUIRE(bf.extract<Reg::field5>() == 0b00000000);
-        REQUIRE(bf.extract<Reg::field6>() == 0b00000100);
-        REQUIRE(bf.extract<Reg::field7>() == 0b00000010);
-        REQUIRE(bf.extract<Reg::field8>() == 0b00000000);
-    }
+    REQUIRE(bf.extract<Reg::field1>() == 0b10000000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b00000000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b00000000);
+    REQUIRE(bf.extract<Reg::field4>() == 0b00010000);
+    REQUIRE(bf.extract<Reg::field5>() == 0b00000000);
+    REQUIRE(bf.extract<Reg::field6>() == 0b00000100);
+    REQUIRE(bf.extract<Reg::field7>() == 0b00000010);
+    REQUIRE(bf.extract<Reg::field8>() == 0b00000000);
+  }
 
-    SECTION("For one field, occupying the whole bitfield")
-    {
-        Bitfields<uint8_t, Field<Reg::field1, 8>> bf;
-        bf.at<Reg::field1>() = 0b10010110;
-        REQUIRE(bf.extract<Reg::field1>() == 0b10010110);
-    }
+  SECTION("For one field, occupying the whole bitfield") {
+    Bitfields<uint8_t, Field<Reg::field1, 8>> bf;
+    bf.at<Reg::field1>() = 0b10010110;
+    REQUIRE(bf.extract<Reg::field1>() == 0b10010110);
+  }
 }
 
-TEST_CASE("Extracts bitfields on 4-byte long bitfield", "[extract]")
-{
-    SECTION("For three fields, evenly aligned")
-    {
-        Bitfields<uint32_t, Field<Reg::field1, 11>, Field<Reg::field2, 11>, Field<Reg::field3, 10>> bf;
+TEST_CASE("Extracts bitfields on 4-byte long bitfield", "[extract]") {
+  SECTION("For three fields, evenly aligned") {
+    Bitfields<uint32_t, Field<Reg::field1, 11>, Field<Reg::field2, 11>,
+              Field<Reg::field3, 10>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b10101010101;
-        bf.at<Reg::field2>() = 0b01101101100;
-        bf.at<Reg::field3>() = 0b0111011110;
+    bf.at<Reg::field1>() = 0b10101010101;
+    bf.at<Reg::field2>() = 0b01101101100;
+    bf.at<Reg::field3>() = 0b0111011110;
 
-        REQUIRE(bf.extract<Reg::field1>() == 0b10101010101000000000000000000000);
-        REQUIRE(bf.extract<Reg::field2>() == 0b00000000000011011011000000000000);
-        REQUIRE(bf.extract<Reg::field3>() == 0b00000000000000000000000111011110);
-    }
+    REQUIRE(bf.extract<Reg::field1>() == 0b10101010101000000000000000000000);
+    REQUIRE(bf.extract<Reg::field2>() == 0b00000000000011011011000000000000);
+    REQUIRE(bf.extract<Reg::field3>() == 0b00000000000000000000000111011110);
+  }
 
-    SECTION("For a two bit bitfield lying across two bytes")
-    {
-        Bitfields<uint32_t, Field<Reg::field1, 15>, Field<Reg::field2, 2>, Field<Reg::field3, 15>> bf;
-        bf.at<Reg::field1>() = 0b000001111100000;
-        bf.at<Reg::field2>() = 0b11;
-        bf.at<Reg::field3>() = 0b000001111100000;
+  SECTION("For a two bit bitfield lying across two bytes") {
+    Bitfields<uint32_t, Field<Reg::field1, 15>, Field<Reg::field2, 2>,
+              Field<Reg::field3, 15>>
+        bf;
+    bf.at<Reg::field1>() = 0b000001111100000;
+    bf.at<Reg::field2>() = 0b11;
+    bf.at<Reg::field3>() = 0b000001111100000;
 
-        REQUIRE(bf.extract<Reg::field2>() == 0b00000000000000011000000000000000);
-    }
+    REQUIRE(bf.extract<Reg::field2>() == 0b00000000000000011000000000000000);
+  }
 }
-

--- a/tests/test_extracting.cpp
+++ b/tests/test_extracting.cpp
@@ -38,8 +38,15 @@ TEST_CASE("Extracts bitfields on one-byte long bitfield", "[extract]") {
   }
 
   SECTION("For each field having size one") {
-    Bitfields<uint8_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 1>, Field<Reg::field4, 1>,
-              Field<Reg::field5, 1>, Field<Reg::field6, 1>, Field<Reg::field7, 1>, Field<Reg::field8, 1>>
+    Bitfields<uint8_t,
+              Field<Reg::field1, 1>,
+              Field<Reg::field2, 1>,
+              Field<Reg::field3, 1>,
+              Field<Reg::field4, 1>,
+              Field<Reg::field5, 1>,
+              Field<Reg::field6, 1>,
+              Field<Reg::field7, 1>,
+              Field<Reg::field8, 1>>
         bf;
 
     bf.at<Reg::field1>() = 0b1;

--- a/tests/test_operations_on_bitfields.cpp
+++ b/tests/test_operations_on_bitfields.cpp
@@ -12,11 +12,8 @@
 
 using namespace jungles;
 
-TEST_CASE("Operations on bitfields for one byte long bitfield",
-          "[operations]") {
-  Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>,
-            Field<Reg::field3, 3>>
-      bf;
+TEST_CASE("Operations on bitfields for one byte long bitfield", "[operations]") {
+  Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>, Field<Reg::field3, 3>> bf;
 
   SECTION("Setting most-right field") {
     bf.at<Reg::field1>() = 0b010;
@@ -41,11 +38,8 @@ TEST_CASE("Operations on bitfields for one byte long bitfield",
   }
 }
 
-TEST_CASE("Operations on bitfields for unsigned as underlying type",
-          "[operations]") {
-  Bitfields<unsigned, Field<Reg::field1, 30>, Field<Reg::field2, 1>,
-            Field<Reg::field3, 1>>
-      bf;
+TEST_CASE("Operations on bitfields for unsigned as underlying type", "[operations]") {
+  Bitfields<unsigned, Field<Reg::field1, 30>, Field<Reg::field2, 1>, Field<Reg::field3, 1>> bf;
 
   bf.at<Reg::field1>() = 0b11111111111111111111111111111;
   bf.at<Reg::field1>() &= ~0b00010000000000000000000000000;
@@ -53,9 +47,7 @@ TEST_CASE("Operations on bitfields for unsigned as underlying type",
 }
 
 TEST_CASE("Operations on bitfields for 8-byte long bitfield", "[operations]") {
-  Bitfields<uint64_t, Field<Reg::field1, 31>, Field<Reg::field2, 5>,
-            Field<Reg::field3, 28>>
-      bf;
+  Bitfields<uint64_t, Field<Reg::field1, 31>, Field<Reg::field2, 5>, Field<Reg::field3, 28>> bf;
 
   bf.at<Reg::field1>() = 0b1111111111111111111111111111111;
   bf.at<Reg::field1>() &= ~0b0100000000000000000000000000000;

--- a/tests/test_operations_on_bitfields.cpp
+++ b/tests/test_operations_on_bitfields.cpp
@@ -5,60 +5,59 @@
  */
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#include "jungles/bitfields.hpp"
+#include <cinttypes>
 
 #include "helpers.hpp"
-
-#include <cinttypes>
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-TEST_CASE("Operations on bitfields for one byte long bitfield", "[operations]")
-{
-    Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>, Field<Reg::field3, 3>> bf;
+TEST_CASE("Operations on bitfields for one byte long bitfield",
+          "[operations]") {
+  Bitfields<uint8_t, Field<Reg::field1, 3>, Field<Reg::field2, 2>,
+            Field<Reg::field3, 3>>
+      bf;
 
-    SECTION("Setting most-right field")
-    {
-        bf.at<Reg::field1>() = 0b010;
-        REQUIRE(bf.at<Reg::field1>() == 0b010);
-    }
+  SECTION("Setting most-right field") {
+    bf.at<Reg::field1>() = 0b010;
+    REQUIRE(bf.at<Reg::field1>() == 0b010);
+  }
 
-    SECTION("Setting field in the middle")
-    {
-        bf.at<Reg::field2>() = 0b11;
-        REQUIRE(bf.at<Reg::field2>() == 0b11);
-    }
+  SECTION("Setting field in the middle") {
+    bf.at<Reg::field2>() = 0b11;
+    REQUIRE(bf.at<Reg::field2>() == 0b11);
+  }
 
-    SECTION("Bitwise OR operation")
-    {
-        bf.at<Reg::field3>() = 0b10;
-        bf.at<Reg::field3>() |= 0b11;
-        REQUIRE(bf.at<Reg::field3>() == 0b11);
-    }
+  SECTION("Bitwise OR operation") {
+    bf.at<Reg::field3>() = 0b10;
+    bf.at<Reg::field3>() |= 0b11;
+    REQUIRE(bf.at<Reg::field3>() == 0b11);
+  }
 
-    SECTION("Bitwise bit clearing")
-    {
-        bf.at<Reg::field3>() = 0b111;
-        bf.at<Reg::field3>() &= ~0b010;
-        REQUIRE(bf.at<Reg::field3>() == 0b101);
-    }
+  SECTION("Bitwise bit clearing") {
+    bf.at<Reg::field3>() = 0b111;
+    bf.at<Reg::field3>() &= ~0b010;
+    REQUIRE(bf.at<Reg::field3>() == 0b101);
+  }
 }
 
-TEST_CASE("Operations on bitfields for unsigned as underlying type", "[operations]")
-{
-    Bitfields<unsigned, Field<Reg::field1, 30>, Field<Reg::field2, 1>, Field<Reg::field3, 1>> bf;
+TEST_CASE("Operations on bitfields for unsigned as underlying type",
+          "[operations]") {
+  Bitfields<unsigned, Field<Reg::field1, 30>, Field<Reg::field2, 1>,
+            Field<Reg::field3, 1>>
+      bf;
 
-    bf.at<Reg::field1>() = 0b11111111111111111111111111111;
-    bf.at<Reg::field1>() &= ~0b00010000000000000000000000000;
-    REQUIRE(bf.at<Reg::field1>() == 0b11101111111111111111111111111);
+  bf.at<Reg::field1>() = 0b11111111111111111111111111111;
+  bf.at<Reg::field1>() &= ~0b00010000000000000000000000000;
+  REQUIRE(bf.at<Reg::field1>() == 0b11101111111111111111111111111);
 }
 
-TEST_CASE("Operations on bitfields for 8-byte long bitfield", "[operations]")
-{
-    Bitfields<uint64_t, Field<Reg::field1, 31>, Field<Reg::field2, 5>, Field<Reg::field3, 28>> bf;
+TEST_CASE("Operations on bitfields for 8-byte long bitfield", "[operations]") {
+  Bitfields<uint64_t, Field<Reg::field1, 31>, Field<Reg::field2, 5>,
+            Field<Reg::field3, 28>>
+      bf;
 
-    bf.at<Reg::field1>() = 0b1111111111111111111111111111111;
-    bf.at<Reg::field1>() &= ~0b0100000000000000000000000000000;
-    REQUIRE(bf.at<Reg::field1>() == 0b1011111111111111111111111111111);
+  bf.at<Reg::field1>() = 0b1111111111111111111111111111111;
+  bf.at<Reg::field1>() &= ~0b0100000000000000000000000000000;
+  REQUIRE(bf.at<Reg::field1>() == 0b1011111111111111111111111111111);
 }

--- a/tests/test_overflow.cpp
+++ b/tests/test_overflow.cpp
@@ -5,63 +5,61 @@
  */
 #include <catch2/catch_test_macros.hpp>
 
-#include "jungles/bitfields.hpp"
-
 #include "helpers.hpp"
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-TEST_CASE("Overflows are not affecting other fields", "[overflow]")
-{
-    SECTION("Overflowing operation truncates the value")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>, Field<Reg::field3, 6>> bf;
+TEST_CASE("Overflows are not affecting other fields", "[overflow]") {
+  SECTION("Overflowing operation truncates the value") {
+    Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>,
+              Field<Reg::field3, 6>>
+        bf;
 
-        bf.at<Reg::field2>() = 0xFFF;
+    bf.at<Reg::field2>() = 0xFFF;
 
-        SECTION("When using operator at()")
-        {
-            REQUIRE(bf.at<Reg::field2>() == 0xFF);
-        }
-
-        SECTION("When extracting")
-        {
-            REQUIRE(bf.extract<Reg::field2>() == 0b0011111111000000);
-        }
-
-        SECTION("When serializing")
-        {
-            REQUIRE(bf.serialize() == 0b0011111111000000);
-        }
+    SECTION("When using operator at()") {
+      REQUIRE(bf.at<Reg::field2>() == 0xFF);
     }
 
-    SECTION("Serialize overflown bitfields with various sizes")
-    {
-        SECTION("Two bit bitfield, occupying bits by the border of two bytes")
-        {
-            Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 2>, Field<Reg::field3, 7>> bf;
-            bf.at<Reg::field1>() = 0b111000000;
-            bf.at<Reg::field2>() = 0b101;
-            bf.at<Reg::field3>() = 0b111100000;
-            REQUIRE(bf.serialize() == 0b1000000011100000);
-        }
-
-        SECTION("One-bit-long bitfield")
-        {
-            Bitfields<uint32_t, Field<Reg::field1, 17>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
-            bf.at<Reg::field1>() = 0b111000000;
-            bf.at<Reg::field2>() = 0b11110;
-            bf.at<Reg::field3>() = 0b0000111;
-            REQUIRE(bf.serialize() == 0b111000000000000000000111);
-        }
-
-        SECTION("Evenly aligned three bitfields over four-byte-long bitfield")
-        {
-            Bitfields<uint32_t, Field<Reg::field1, 10>, Field<Reg::field2, 11>, Field<Reg::field3, 11>> bf;
-            bf.at<Reg::field1>() = 0b111111000000;
-            bf.at<Reg::field2>() = 0b11111110010101001;
-            bf.at<Reg::field3>() = 0b1111111111000111000;
-            REQUIRE(bf.serialize() == 0b11110000001001010100111000111000);
-        }
+    SECTION("When extracting") {
+      REQUIRE(bf.extract<Reg::field2>() == 0b0011111111000000);
     }
+
+    SECTION("When serializing") {
+      REQUIRE(bf.serialize() == 0b0011111111000000);
+    }
+  }
+
+  SECTION("Serialize overflown bitfields with various sizes") {
+    SECTION("Two bit bitfield, occupying bits by the border of two bytes") {
+      Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 2>,
+                Field<Reg::field3, 7>>
+          bf;
+      bf.at<Reg::field1>() = 0b111000000;
+      bf.at<Reg::field2>() = 0b101;
+      bf.at<Reg::field3>() = 0b111100000;
+      REQUIRE(bf.serialize() == 0b1000000011100000);
+    }
+
+    SECTION("One-bit-long bitfield") {
+      Bitfields<uint32_t, Field<Reg::field1, 17>, Field<Reg::field2, 1>,
+                Field<Reg::field3, 14>>
+          bf;
+      bf.at<Reg::field1>() = 0b111000000;
+      bf.at<Reg::field2>() = 0b11110;
+      bf.at<Reg::field3>() = 0b0000111;
+      REQUIRE(bf.serialize() == 0b111000000000000000000111);
+    }
+
+    SECTION("Evenly aligned three bitfields over four-byte-long bitfield") {
+      Bitfields<uint32_t, Field<Reg::field1, 10>, Field<Reg::field2, 11>,
+                Field<Reg::field3, 11>>
+          bf;
+      bf.at<Reg::field1>() = 0b111111000000;
+      bf.at<Reg::field2>() = 0b11111110010101001;
+      bf.at<Reg::field3>() = 0b1111111111000111000;
+      REQUIRE(bf.serialize() == 0b11110000001001010100111000111000);
+    }
+  }
 }

--- a/tests/test_overflow.cpp
+++ b/tests/test_overflow.cpp
@@ -12,30 +12,20 @@ using namespace jungles;
 
 TEST_CASE("Overflows are not affecting other fields", "[overflow]") {
   SECTION("Overflowing operation truncates the value") {
-    Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>,
-              Field<Reg::field3, 6>>
-        bf;
+    Bitfields<uint16_t, Field<Reg::field1, 2>, Field<Reg::field2, 8>, Field<Reg::field3, 6>> bf;
 
     bf.at<Reg::field2>() = 0xFFF;
 
-    SECTION("When using operator at()") {
-      REQUIRE(bf.at<Reg::field2>() == 0xFF);
-    }
+    SECTION("When using operator at()") { REQUIRE(bf.at<Reg::field2>() == 0xFF); }
 
-    SECTION("When extracting") {
-      REQUIRE(bf.extract<Reg::field2>() == 0b0011111111000000);
-    }
+    SECTION("When extracting") { REQUIRE(bf.extract<Reg::field2>() == 0b0011111111000000); }
 
-    SECTION("When serializing") {
-      REQUIRE(bf.serialize() == 0b0011111111000000);
-    }
+    SECTION("When serializing") { REQUIRE(bf.serialize() == 0b0011111111000000); }
   }
 
   SECTION("Serialize overflown bitfields with various sizes") {
     SECTION("Two bit bitfield, occupying bits by the border of two bytes") {
-      Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 2>,
-                Field<Reg::field3, 7>>
-          bf;
+      Bitfields<uint16_t, Field<Reg::field1, 7>, Field<Reg::field2, 2>, Field<Reg::field3, 7>> bf;
       bf.at<Reg::field1>() = 0b111000000;
       bf.at<Reg::field2>() = 0b101;
       bf.at<Reg::field3>() = 0b111100000;
@@ -43,9 +33,7 @@ TEST_CASE("Overflows are not affecting other fields", "[overflow]") {
     }
 
     SECTION("One-bit-long bitfield") {
-      Bitfields<uint32_t, Field<Reg::field1, 17>, Field<Reg::field2, 1>,
-                Field<Reg::field3, 14>>
-          bf;
+      Bitfields<uint32_t, Field<Reg::field1, 17>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
       bf.at<Reg::field1>() = 0b111000000;
       bf.at<Reg::field2>() = 0b11110;
       bf.at<Reg::field3>() = 0b0000111;
@@ -53,9 +41,7 @@ TEST_CASE("Overflows are not affecting other fields", "[overflow]") {
     }
 
     SECTION("Evenly aligned three bitfields over four-byte-long bitfield") {
-      Bitfields<uint32_t, Field<Reg::field1, 10>, Field<Reg::field2, 11>,
-                Field<Reg::field3, 11>>
-          bf;
+      Bitfields<uint32_t, Field<Reg::field1, 10>, Field<Reg::field2, 11>, Field<Reg::field3, 11>> bf;
       bf.at<Reg::field1>() = 0b111111000000;
       bf.at<Reg::field2>() = 0b11111110010101001;
       bf.at<Reg::field3>() = 0b1111111111000111000;

--- a/tests/test_serializing.cpp
+++ b/tests/test_serializing.cpp
@@ -11,9 +11,7 @@
 using namespace jungles;
 
 TEST_CASE("One-byte-long bitfield group is serialized", "[serializing]") {
-  Bitfields<uint8_t, Field<Reg::field1, 2>, Field<Reg::field2, 4>,
-            Field<Reg::field3, 2>>
-      bf;
+  Bitfields<uint8_t, Field<Reg::field1, 2>, Field<Reg::field2, 4>, Field<Reg::field3, 2>> bf;
 
   bf.at<Reg::field1>() = 0b10;
   bf.at<Reg::field2>() = 0b0110;
@@ -24,9 +22,7 @@ TEST_CASE("One-byte-long bitfield group is serialized", "[serializing]") {
 
 TEST_CASE("Two-byte-long bitfield group is serialized", "[serializing]") {
   SECTION("Evenly aligned, four bitfields") {
-    Bitfields<uint16_t, Field<Reg::field1, 4>, Field<Reg::field2, 4>,
-              Field<Reg::field3, 4>, Field<Reg::field4, 4>>
-        bf;
+    Bitfields<uint16_t, Field<Reg::field1, 4>, Field<Reg::field2, 4>, Field<Reg::field3, 4>, Field<Reg::field4, 4>> bf;
 
     bf.at<Reg::field1>() = 0b0110;
     bf.at<Reg::field2>() = 0b1001;
@@ -37,9 +33,7 @@ TEST_CASE("Two-byte-long bitfield group is serialized", "[serializing]") {
   }
 
   SECTION("Two small bitfields, and one big") {
-    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
-              Field<Reg::field3, 14>>
-        bf;
+    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
 
     bf.at<Reg::field1>() = 0b1;
     bf.at<Reg::field2>() = 0b0;
@@ -50,9 +44,7 @@ TEST_CASE("Two-byte-long bitfield group is serialized", "[serializing]") {
 }
 
 TEST_CASE("Four-byte-long bitfield group is serialized", "[serializing]") {
-  Bitfields<uint32_t, Field<Reg::field1, 7>, Field<Reg::field2, 21>,
-            Field<Reg::field3, 4>>
-      bf;
+  Bitfields<uint32_t, Field<Reg::field1, 7>, Field<Reg::field2, 21>, Field<Reg::field3, 4>> bf;
 
   bf.at<Reg::field1>() = 0b1010101;
   bf.at<Reg::field2>() = 0b000011111111111110000;

--- a/tests/test_serializing.cpp
+++ b/tests/test_serializing.cpp
@@ -5,58 +5,58 @@
  */
 #include <catch2/catch_test_macros.hpp>
 
-#include "jungles/bitfields.hpp"
-
 #include "helpers.hpp"
+#include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-TEST_CASE("One-byte-long bitfield group is serialized", "[serializing]")
-{
-    Bitfields<uint8_t, Field<Reg::field1, 2>, Field<Reg::field2, 4>, Field<Reg::field3, 2>> bf;
+TEST_CASE("One-byte-long bitfield group is serialized", "[serializing]") {
+  Bitfields<uint8_t, Field<Reg::field1, 2>, Field<Reg::field2, 4>,
+            Field<Reg::field3, 2>>
+      bf;
 
-    bf.at<Reg::field1>() = 0b10;
-    bf.at<Reg::field2>() = 0b0110;
-    bf.at<Reg::field3>() = 0b01;
+  bf.at<Reg::field1>() = 0b10;
+  bf.at<Reg::field2>() = 0b0110;
+  bf.at<Reg::field3>() = 0b01;
 
-    REQUIRE(bf.serialize() == 0b10011001);
+  REQUIRE(bf.serialize() == 0b10011001);
 }
 
-TEST_CASE("Two-byte-long bitfield group is serialized", "[serializing]")
-{
-    SECTION("Evenly aligned, four bitfields")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 4>, Field<Reg::field2, 4>, Field<Reg::field3, 4>, Field<Reg::field4, 4>>
-            bf;
+TEST_CASE("Two-byte-long bitfield group is serialized", "[serializing]") {
+  SECTION("Evenly aligned, four bitfields") {
+    Bitfields<uint16_t, Field<Reg::field1, 4>, Field<Reg::field2, 4>,
+              Field<Reg::field3, 4>, Field<Reg::field4, 4>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b0110;
-        bf.at<Reg::field2>() = 0b1001;
-        bf.at<Reg::field3>() = 0b1010;
-        bf.at<Reg::field4>() = 0b0101;
+    bf.at<Reg::field1>() = 0b0110;
+    bf.at<Reg::field2>() = 0b1001;
+    bf.at<Reg::field3>() = 0b1010;
+    bf.at<Reg::field4>() = 0b0101;
 
-        REQUIRE(bf.serialize() == 0b0110100110100101);
-    }
+    REQUIRE(bf.serialize() == 0b0110100110100101);
+  }
 
-    SECTION("Two small bitfields, and one big")
-    {
-        Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>, Field<Reg::field3, 14>> bf;
+  SECTION("Two small bitfields, and one big") {
+    Bitfields<uint16_t, Field<Reg::field1, 1>, Field<Reg::field2, 1>,
+              Field<Reg::field3, 14>>
+        bf;
 
-        bf.at<Reg::field1>() = 0b1;
-        bf.at<Reg::field2>() = 0b0;
-        bf.at<Reg::field3>() = 0b00001111001100;
+    bf.at<Reg::field1>() = 0b1;
+    bf.at<Reg::field2>() = 0b0;
+    bf.at<Reg::field3>() = 0b00001111001100;
 
-        REQUIRE(bf.serialize() == 0b1000001111001100);
-    }
+    REQUIRE(bf.serialize() == 0b1000001111001100);
+  }
 }
 
-TEST_CASE("Four-byte-long bitfield group is serialized", "[serializing]")
-{
-    Bitfields<uint32_t, Field<Reg::field1, 7>, Field<Reg::field2, 21>, Field<Reg::field3, 4>> bf;
+TEST_CASE("Four-byte-long bitfield group is serialized", "[serializing]") {
+  Bitfields<uint32_t, Field<Reg::field1, 7>, Field<Reg::field2, 21>,
+            Field<Reg::field3, 4>>
+      bf;
 
-    bf.at<Reg::field1>() = 0b1010101;
-    bf.at<Reg::field2>() = 0b000011111111111110000;
-    bf.at<Reg::field3>() = 0b0110;
+  bf.at<Reg::field1>() = 0b1010101;
+  bf.at<Reg::field2>() = 0b000011111111111110000;
+  bf.at<Reg::field3>() = 0b0110;
 
-    REQUIRE(bf.serialize() == 0b10101010000111111111111100000110);
+  REQUIRE(bf.serialize() == 0b10101010000111111111111100000110);
 }
-

--- a/tests/test_various_id_types.cpp
+++ b/tests/test_various_id_types.cpp
@@ -1,43 +1,34 @@
 /**
  * @file	test_various_id_types.cpp
- * @brief	Creates bitfields with various ID types, to check whether it compiles.
+ * @brief	Creates bitfields with various ID types, to check whether it
+ * compiles.
  * @author	Kacper Kowalski - kacper.s.kowalski@gmail.com
  */
 #include "jungles/bitfields.hpp"
 
 using namespace jungles;
 
-int main(void)
-{
-    auto compile_enum_as_id{[]() {
-        enum SomeEnum
-        {
-            EnumVal1,
-            EnumVal2,
-            EnumVal3
-        };
+int main(void) {
+  auto compile_enum_as_id{[]() {
+    enum SomeEnum { EnumVal1, EnumVal2, EnumVal3 };
 
-        Bitfields<uint8_t, Field<EnumVal1, 2>, Field<EnumVal2, 3>, Field<EnumVal3, 3>>{};
-    }};
+    Bitfields<uint8_t, Field<EnumVal1, 2>, Field<EnumVal2, 3>,
+              Field<EnumVal3, 3>>{};
+  }};
 
-    auto compile_int_as_id{[]() {
-        Bitfields<uint8_t, Field<10, 2>, Field<20, 3>, Field<30, 3>>{};
-    }};
+  auto compile_int_as_id{
+      []() { Bitfields<uint8_t, Field<10, 2>, Field<20, 3>, Field<30, 3>>{}; }};
 
-    auto compile_enum_class_as_id{[]() {
-        enum class SomeEnumClass
-        {
-            V1,
-            V2,
-            V3
-        };
+  auto compile_enum_class_as_id{[]() {
+    enum class SomeEnumClass { V1, V2, V3 };
 
-        Bitfields<uint8_t, Field<SomeEnumClass::V1, 2>, Field<SomeEnumClass::V2, 3>, Field<SomeEnumClass::V3, 3>>{};
-    }};
+    Bitfields<uint8_t, Field<SomeEnumClass::V1, 2>, Field<SomeEnumClass::V2, 3>,
+              Field<SomeEnumClass::V3, 3>>{};
+  }};
 
-    compile_enum_as_id();
-    compile_int_as_id();
-    compile_enum_class_as_id();
+  compile_enum_as_id();
+  compile_int_as_id();
+  compile_enum_class_as_id();
 
-    return 0;
+  return 0;
 }

--- a/tests/test_various_id_types.cpp
+++ b/tests/test_various_id_types.cpp
@@ -12,18 +12,15 @@ int main(void) {
   auto compile_enum_as_id{[]() {
     enum SomeEnum { EnumVal1, EnumVal2, EnumVal3 };
 
-    Bitfields<uint8_t, Field<EnumVal1, 2>, Field<EnumVal2, 3>,
-              Field<EnumVal3, 3>>{};
+    Bitfields<uint8_t, Field<EnumVal1, 2>, Field<EnumVal2, 3>, Field<EnumVal3, 3>>{};
   }};
 
-  auto compile_int_as_id{
-      []() { Bitfields<uint8_t, Field<10, 2>, Field<20, 3>, Field<30, 3>>{}; }};
+  auto compile_int_as_id{[]() { Bitfields<uint8_t, Field<10, 2>, Field<20, 3>, Field<30, 3>>{}; }};
 
   auto compile_enum_class_as_id{[]() {
     enum class SomeEnumClass { V1, V2, V3 };
 
-    Bitfields<uint8_t, Field<SomeEnumClass::V1, 2>, Field<SomeEnumClass::V2, 3>,
-              Field<SomeEnumClass::V3, 3>>{};
+    Bitfields<uint8_t, Field<SomeEnumClass::V1, 2>, Field<SomeEnumClass::V2, 3>, Field<SomeEnumClass::V3, 3>>{};
   }};
 
   compile_enum_as_id();


### PR DESCRIPTION
Implementing `clang-tidy` and `clang-format` per [request in PR#4](https://github.com/KKoovalsky/PortableBitfields/pull/4#issuecomment-3023490429).