### PR TITLE
fix: Add static_cast to resolve conversion warnings under ARM GCC 13.3.1

### DIFF
--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -74,7 +74,7 @@ class Bitfields
             auto mask{field_masks[i]};
             auto masked_value{mask & preload};
             auto shift{field_shifts[i]};
-            field_values[i] = masked_value >> shift;
+            field_values[i] = static_cast<UnderlyingType>(masked_value >> shift);
         }
     }
 
@@ -141,7 +141,7 @@ class Bitfields
             // and shifting (int << uint64_t) is undefined behavior; see:
             // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
             auto one{static_cast<UnderlyingType>(1)};
-            field_masks[i] = (one << field_size) - 1;
+            field_masks[i] = static_cast<UnderlyingType>((one << field_size) - 1);
         }
 
         return field_masks;
@@ -155,7 +155,7 @@ class Bitfields
         {
             auto mask{non_shifted_field_masks[i]};
             auto shift{field_shifts[i]};
-            masks[i] = mask << shift;
+            masks[i] = static_cast<UnderlyingType>(mask << shift);
         }
 
         return masks;


### PR DESCRIPTION
Warning seen on Line 77 and 144. Added cast on 158 as well to be consistent.

This was the GCC warning, https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wconversion